### PR TITLE
Set initial application state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@ Changelog
 =========
 
 
+Version 0.2
+----------------------------
+
+* Expose API to set initial application state
+
+
 Version 0.1.1
 ----------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Changelog
 =========
 
 
-Version 0.2
+Version 0.2.0
 ----------------------------
 
 * Expose API to set initial application state

--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ UBStartupReason const UBStartupReasonOutOfMemory = @"out_of_memory";
 To integrate the StartupReasonReporter into your project add the following to your `Podfile`:
 
 ```ruby
-pod 'StartupReasonReporter', '~> 0.2'
+pod 'StartupReasonReporter', '~> 0.2.0'
 ```
 
 To integrate only the `UBApplicationStartupReasonReporterPriorRunInfoProtocol` protocol, but not the implementation, add the following to your `Podfile`:
 
 ```ruby
-pod 'StartupReasonReporter/Core', '~> 0.2'
+pod 'StartupReasonReporter/Core', '~> 0.2.0'
 ```
 
 #### Carthage
@@ -93,7 +93,7 @@ pod 'StartupReasonReporter/Core', '~> 0.2'
 To integrate the StartupReasonReporter into your project using Carthage add the following to your `Cartfile`:
 
 ```ruby
-github "uber/startup-reason-reporter" ~> 0.2
+github "uber/startup-reason-reporter" ~> 0.2.0
 ```
 
 ## Contributions

--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ let crashedOnPriorLaunch = ...
 let previousRunInfo: ApplicationStartupReasonReporterProtocol = ...
 
 // Initialize the startup reason reporter
-let startupReasonReporter = ApplicationStartupReasonReporter(notificationCenter: NotificationCenter.default, 
-previousRunDidCrash: crashedOnPreviousLaunch, 
-previousRunInfo: previousRunInfo, 
-debugging: false)
+let startupReasonReporter = ApplicationStartupReasonReporter(notificationCenter: NotificationCenter.default,
+previousRunDidCrash: crashedOnPreviousLaunch,
+previousRunInfo: previousRunInfo,
+debugging: false,
+applicationState: UIApplication.shared.applicationState)
 
 // Profit
 let startupReason =  startupReasonReporter.startupReason
@@ -39,7 +40,8 @@ id<UBApplicationStartupReasonReporterPriorRunInfoProtocol> runInfo = ...
 UBApplicationStartupReasonReporter *startupReasonReporter = [[UBApplicationStartupReasonReporter alloc] initWithNotificationCenter:[NSNotificationCenter defaultCenter]
         previousRunDidCrash:crashedOnPriorLaunch
         previousRunInfo:runInfo
-        debugging:[UBBuildType isDebugBuild]];
+        debugging:[UBBuildType isDebugBuild]]
+        applicationState:[UIApplication sharedApplication].applicationState;
 
 // Profit
 UBStartupReason startupReason = startupReasonReporter.startupReason
@@ -77,13 +79,13 @@ UBStartupReason const UBStartupReasonOutOfMemory = @"out_of_memory";
 To integrate the StartupReasonReporter into your project add the following to your `Podfile`:
 
 ```ruby
-pod 'StartupReasonReporter', '~> 0.1'
+pod 'StartupReasonReporter', '~> 0.2'
 ```
 
 To integrate only the `UBApplicationStartupReasonReporterPriorRunInfoProtocol` protocol, but not the implementation, add the following to your `Podfile`:
 
 ```ruby
-pod 'StartupReasonReporter/Core', '~> 0.1'
+pod 'StartupReasonReporter/Core', '~> 0.2'
 ```
 
 #### Carthage
@@ -91,7 +93,7 @@ pod 'StartupReasonReporter/Core', '~> 0.1'
 To integrate the StartupReasonReporter into your project using Carthage add the following to your `Cartfile`:
 
 ```ruby
-github "uber/startup-reason-reporter" ~> 0.1
+github "uber/startup-reason-reporter" ~> 0.2
 ```
 
 ## Contributions

--- a/StartupReasonReporter.podspec
+++ b/StartupReasonReporter.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'StartupReasonReporter'
-  s.version          = '0.1.0'
+  s.version          = '0.2.0'
   s.summary          = 'Provides the reason that an iOS application has launched.'
 
 # This description is used to generate tags and improve search results.
@@ -25,9 +25,9 @@ The Startup Reason Reporter provides developers the the reason that an iOS appli
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.source           = { :git => 'https://github.com/uber/startup-reason-reporter.git', :tag => s.version.to_s }
   s.author           = "Uber"
-  
+
   s.ios.deployment_target = '8.0'
-  
+
   s.subspec 'Core' do |core|
     core.source_files = 'StartupReasonReporter/StartupReasonReporter/*'
   end

--- a/StartupReasonReporter/Info.plist
+++ b/StartupReasonReporter/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.1</string>
+	<string>0.2</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/StartupReasonReporter/Info.plist
+++ b/StartupReasonReporter/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2</string>
+	<string>0.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/StartupReasonReporter/StartupReasonReporter/UBApplicationStartupReasonReporter.h
+++ b/StartupReasonReporter/StartupReasonReporter/UBApplicationStartupReasonReporter.h
@@ -64,11 +64,13 @@ NS_SWIFT_NAME(ApplicationStartupReasonReporter)
  @param previousRunDidCrash Indicates whether the prior run was a crash
  @param previousRunInfo An implementation of UBApplicationStartupReasonReporterPriorRunInfoProtocol which contains information about the prior run and will store information about the current run.
  @param debugging True if this app run is for debugging, false otherwise.  This is useful if the app is being developed in the simulator, for instance.
+ @param applicationState The starting state of the application. This to tell if the app is being launched in the background.
  */
 - (instancetype)initWithNotificationCenter:(NSNotificationCenter *)notificationCenter
                        previousRunDidCrash:(BOOL)previousRunDidCrash
                            previousRunInfo:(id<UBApplicationStartupReasonReporterPriorRunInfoProtocol>)previousRunInfo
-                                 debugging:(BOOL)debugging;
+                                 debugging:(BOOL)debugging
+                          applicationState:(UIApplicationState)applicationState;
 
 @end
 

--- a/StartupReasonReporter/StartupReasonReporter/UBApplicationStartupReasonReporter.h
+++ b/StartupReasonReporter/StartupReasonReporter/UBApplicationStartupReasonReporter.h
@@ -64,7 +64,7 @@ NS_SWIFT_NAME(ApplicationStartupReasonReporter)
  @param previousRunDidCrash Indicates whether the prior run was a crash
  @param previousRunInfo An implementation of UBApplicationStartupReasonReporterPriorRunInfoProtocol which contains information about the prior run and will store information about the current run.
  @param debugging True if this app run is for debugging, false otherwise.  This is useful if the app is being developed in the simulator, for instance.
- @param applicationState The starting state of the application. This to tell if the app is being launched in the background.
+ @param applicationState The current state of the application. This to tell if the app is being launched in the background.
  */
 - (instancetype)initWithNotificationCenter:(NSNotificationCenter *)notificationCenter
                        previousRunDidCrash:(BOOL)previousRunDidCrash

--- a/StartupReasonReporter/StartupReasonReporter/UBApplicationStartupReasonReporter.m
+++ b/StartupReasonReporter/StartupReasonReporter/UBApplicationStartupReasonReporter.m
@@ -62,7 +62,6 @@ UBStartupReason const UBStartupReasonOutOfMemory = @"out_of_memory";
         _previousAppVersion = _currentAppVersion;
         _currentOSVersion = [[UIDevice currentDevice] systemVersion];
         _previousOSVersion = _currentOSVersion;
-        // Application state will be background when the app is launched in the background via silent push
         _backgrounded = applicationState == UIApplicationStateBackground;
         _didTerminate = NO;
         _currentBootTime = [UBApplicationStartupReasonReporter systemBootTime];

--- a/StartupReasonReporter/StartupReasonReporter/UBApplicationStartupReasonReporter.m
+++ b/StartupReasonReporter/StartupReasonReporter/UBApplicationStartupReasonReporter.m
@@ -50,7 +50,7 @@ UBStartupReason const UBStartupReasonOutOfMemory = @"out_of_memory";
     return 0;
 }
 
-- (instancetype)initWithNotificationCenter:(NSNotificationCenter *)notificationCenter previousRunDidCrash:(BOOL)previousRunDidCrash previousRunInfo:(id<UBApplicationStartupReasonReporterPriorRunInfoProtocol>)previousRunInfo debugging:(BOOL)debugging
+- (instancetype)initWithNotificationCenter:(NSNotificationCenter *)notificationCenter previousRunDidCrash:(BOOL)previousRunDidCrash previousRunInfo:(id<UBApplicationStartupReasonReporterPriorRunInfoProtocol>)previousRunInfo debugging:(BOOL)debugging applicationState:(UIApplicationState)applicationState
 {
     self = [super init];
     if (self) {
@@ -62,7 +62,8 @@ UBStartupReason const UBStartupReasonOutOfMemory = @"out_of_memory";
         _previousAppVersion = _currentAppVersion;
         _currentOSVersion = [[UIDevice currentDevice] systemVersion];
         _previousOSVersion = _currentOSVersion;
-        _backgrounded = NO;
+        // Application state will be background when the app is launched in the background via silent push
+        _backgrounded = applicationState == UIApplicationStateBackground;
         _didTerminate = NO;
         _currentBootTime = [UBApplicationStartupReasonReporter systemBootTime];
         _previousBootTime = 0;


### PR DESCRIPTION
This is to account for situations where the application is launched in the background via a push notification or other means. If the app was terminated before the user foregrounded the application an OOM was incorrectly attributed as the cause of app termination.
