### PR TITLE
Use notification relay to update app state. Version 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ Changelog
 =========
 
 
+Version 0.3.0
+----------------------------
+
+* Change notification handling and storage layer to improve OOM accuracy.
+
 Version 0.2.0
 ----------------------------
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -4,9 +4,13 @@ PODS:
 DEPENDENCIES:
   - OCMock (~> 3.0)
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - OCMock
+
 SPEC CHECKSUMS:
   OCMock: f3f61e6eaa16038c30caa5798c5e49d3307b6f22
 
 PODFILE CHECKSUM: a4a540cd891f0fbf8a5475fde780a112960ea07c
 
-COCOAPODS: 1.2.1
+COCOAPODS: 1.5.3

--- a/StartupReasonReporter.podspec
+++ b/StartupReasonReporter.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'StartupReasonReporter'
-  s.version          = '0.2.0'
+  s.version          = '0.3.0'
   s.summary          = 'Provides the reason that an iOS application has launched.'
 
 # This description is used to generate tags and improve search results.

--- a/StartupReasonReporter.xcodeproj/project.pbxproj
+++ b/StartupReasonReporter.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		36A86CDE20BE2DDD00E61398 /* UBApplicationStartupReasonReporterNotificationRelay.h in Headers */ = {isa = PBXBuildFile; fileRef = 36A86CDC20BE2DDD00E61398 /* UBApplicationStartupReasonReporterNotificationRelay.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		36A86CDF20BE2DDD00E61398 /* UBApplicationStartupReasonReporterNotificationRelay.m in Sources */ = {isa = PBXBuildFile; fileRef = 36A86CDD20BE2DDD00E61398 /* UBApplicationStartupReasonReporterNotificationRelay.m */; };
+		36A86CE220BE2DFB00E61398 /* UBApplicationStartupReasonReporterNotificationRelayTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 36A86CE020BE2DFB00E61398 /* UBApplicationStartupReasonReporterNotificationRelayTests.m */; };
+		36A86CE320BE2DFB00E61398 /* UBApplicationStartupReasonReporterPriorRunInfoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 36A86CE120BE2DFB00E61398 /* UBApplicationStartupReasonReporterPriorRunInfoTests.m */; };
 		3A096D351EB7DEBD00F7DF5B /* StartupReasonReporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A096D341EB7DE5C00F7DF5B /* StartupReasonReporter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3AE8A23A1EA14A4E00AA6B9E /* StartupReasonReporter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AE8A2301EA14A4E00AA6B9E /* StartupReasonReporter.framework */; };
 		617190381EB2B47400057990 /* UBApplicationStartupReasonReporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 617190371EB2B47400057990 /* UBApplicationStartupReasonReporter.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -31,6 +35,10 @@
 
 /* Begin PBXFileReference section */
 		16380E96F12BA873DFC03D2D /* libPods-StartupReasonReporterTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-StartupReasonReporterTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		36A86CDC20BE2DDD00E61398 /* UBApplicationStartupReasonReporterNotificationRelay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UBApplicationStartupReasonReporterNotificationRelay.h; path = ApplicationStartupReasonReporterNotificationRelay/UBApplicationStartupReasonReporterNotificationRelay.h; sourceTree = "<group>"; };
+		36A86CDD20BE2DDD00E61398 /* UBApplicationStartupReasonReporterNotificationRelay.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UBApplicationStartupReasonReporterNotificationRelay.m; path = ApplicationStartupReasonReporterNotificationRelay/UBApplicationStartupReasonReporterNotificationRelay.m; sourceTree = "<group>"; };
+		36A86CE020BE2DFB00E61398 /* UBApplicationStartupReasonReporterNotificationRelayTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UBApplicationStartupReasonReporterNotificationRelayTests.m; sourceTree = "<group>"; };
+		36A86CE120BE2DFB00E61398 /* UBApplicationStartupReasonReporterPriorRunInfoTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UBApplicationStartupReasonReporterPriorRunInfoTests.m; sourceTree = "<group>"; };
 		3A096D341EB7DE5C00F7DF5B /* StartupReasonReporter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StartupReasonReporter.h; sourceTree = "<group>"; };
 		3AE8A2301EA14A4E00AA6B9E /* StartupReasonReporter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StartupReasonReporter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AE8A2341EA14A4E00AA6B9E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -105,6 +113,8 @@
 				6171903A1EB2B4DB00057990 /* UBApplicationStartupReasonReporterPriorRunInfo.h */,
 				6171903B1EB2B4DB00057990 /* UBApplicationStartupReasonReporterPriorRunInfo.m */,
 				6171903C1EB2B4DB00057990 /* UBApplicationStartupReasonReporterPriorRunInfoProtocol.h */,
+				36A86CDC20BE2DDD00E61398 /* UBApplicationStartupReasonReporterNotificationRelay.h */,
+				36A86CDD20BE2DDD00E61398 /* UBApplicationStartupReasonReporterNotificationRelay.m */,
 				3AE8A2341EA14A4E00AA6B9E /* Info.plist */,
 				3A096D341EB7DE5C00F7DF5B /* StartupReasonReporter.h */,
 			);
@@ -114,6 +124,8 @@
 		3AE8A23D1EA14A4E00AA6B9E /* StartupReasonReporterTests */ = {
 			isa = PBXGroup;
 			children = (
+				36A86CE020BE2DFB00E61398 /* UBApplicationStartupReasonReporterNotificationRelayTests.m */,
+				36A86CE120BE2DFB00E61398 /* UBApplicationStartupReasonReporterPriorRunInfoTests.m */,
 				61C904001EB2C407008593BF /* UBApplicationStartupReasonReporterTests.m */,
 				3AE8A2401EA14A4E00AA6B9E /* Info.plist */,
 			);
@@ -138,6 +150,7 @@
 				6171903E1EB2B4DB00057990 /* UBApplicationStartupReasonReporterPriorRunInfo.h in Headers */,
 				617190401EB2B4DB00057990 /* UBApplicationStartupReasonReporterPriorRunInfoProtocol.h in Headers */,
 				617190381EB2B47400057990 /* UBApplicationStartupReasonReporter.h in Headers */,
+				36A86CDE20BE2DDD00E61398 /* UBApplicationStartupReasonReporterNotificationRelay.h in Headers */,
 				3A096D351EB7DEBD00F7DF5B /* StartupReasonReporter.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -171,8 +184,6 @@
 				3AE8A2351EA14A4E00AA6B9E /* Sources */,
 				3AE8A2361EA14A4E00AA6B9E /* Frameworks */,
 				3AE8A2371EA14A4E00AA6B9E /* Resources */,
-				C01E4EFBE90FD18BED1CB6A0 /* [CP] Embed Pods Frameworks */,
-				A8A367EC7A4C70C93BC85B89 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -246,43 +257,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-StartupReasonReporterTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		A8A367EC7A4C70C93BC85B89 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-StartupReasonReporterTests/Pods-StartupReasonReporterTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		C01E4EFBE90FD18BED1CB6A0 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-StartupReasonReporterTests/Pods-StartupReasonReporterTests-frameworks.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -293,6 +277,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BECE33401F4D96D100B359CA /* README.md in Sources */,
+				36A86CDF20BE2DDD00E61398 /* UBApplicationStartupReasonReporterNotificationRelay.m in Sources */,
 				6171903D1EB2B4DB00057990 /* UBApplicationStartupReasonReporter.m in Sources */,
 				6171903F1EB2B4DB00057990 /* UBApplicationStartupReasonReporterPriorRunInfo.m in Sources */,
 			);
@@ -302,7 +287,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				36A86CE320BE2DFB00E61398 /* UBApplicationStartupReasonReporterPriorRunInfoTests.m in Sources */,
 				618915D11EB2CFBC0000CBFA /* UBApplicationStartupReasonReporterTests.m in Sources */,
+				36A86CE220BE2DFB00E61398 /* UBApplicationStartupReasonReporterNotificationRelayTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/StartupReasonReporter/ApplicationStartupReasonReporterNotificationRelay/UBApplicationStartupReasonReporterNotificationRelay.h
+++ b/StartupReasonReporter/ApplicationStartupReasonReporterNotificationRelay/UBApplicationStartupReasonReporterNotificationRelay.h
@@ -1,0 +1,61 @@
+//
+//  Copyright (c) Uber Technologies, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ *  Subscriber protocol which is used to respond to notifications emitted.
+ */
+NS_SWIFT_NAME(ApplicationStartupReasonReporterNotificationRelaySubscriber)
+@protocol UBApplicationStartupReasonReporterNotificationRelaySubscriber
+
+@required
+
+/**
+ *  Perform any work as a result of the given notification.
+ *  @param notification the notification emitted.
+ */
+- (void)processNotification:(NSNotification *)notification;
+
+@end
+
+/**
+ *  Notification relay protocol to relay notifications to a set of subscribers.
+ */
+NS_SWIFT_NAME(ApplicationStartupReasonReporterNotificationRelayProtocol)
+@protocol UBApplicationStartupReasonReporterNotificationRelayProtocol
+
+@required
+
+/**
+ *  Add a subscriber to the set of subscribers responding to notifications.
+ *  @param subscriber the subscriber to add.
+ */
+- (void)addSubscriber:(id<UBApplicationStartupReasonReporterNotificationRelaySubscriber>)subscriber;
+
+/**
+ *  Remove a subscriber from the set of subscribers responding to notifications.
+ *  @param subscriber the subscriber to remove.
+ */
+- (void)removeSubscriber:(id<UBApplicationStartupReasonReporterNotificationRelaySubscriber>)subscriber;
+
+/**
+ *  Relays the notification to the set of subscribers.
+ *  @param notification the notification to relay.
+ */
+- (void)updateApplicationStateNotification:(NSNotification *)notification;
+
+@end
+
+/**
+ *  Notification relay class to relay notifications to a set of subscribers.
+ */
+NS_SWIFT_NAME(ApplicationStartupReasonReporterNotificationRelay)
+@interface UBApplicationStartupReasonReporterNotificationRelay : NSObject <UBApplicationStartupReasonReporterNotificationRelayProtocol>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/StartupReasonReporter/ApplicationStartupReasonReporterNotificationRelay/UBApplicationStartupReasonReporterNotificationRelay.m
+++ b/StartupReasonReporter/ApplicationStartupReasonReporterNotificationRelay/UBApplicationStartupReasonReporterNotificationRelay.m
@@ -1,0 +1,55 @@
+//
+//  Copyright (c) Uber Technologies, Inc. All rights reserved.
+//
+
+#import "UBApplicationStartupReasonReporterNotificationRelay.h"
+
+
+@interface UBApplicationStartupReasonReporterNotificationRelay ()
+
+@property (nonatomic, readonly) NSMutableSet<id<UBApplicationStartupReasonReporterNotificationRelaySubscriber>> *subscribers;
+@property (nonatomic, readonly) NSObject *subscribersLockToken;
+
+@end
+
+
+@implementation UBApplicationStartupReasonReporterNotificationRelay
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _subscribers = [[NSMutableSet<UBApplicationStartupReasonReporterNotificationRelaySubscriber> alloc] init];
+        _subscribersLockToken = [[NSObject alloc] init];
+    }
+
+    return self;
+}
+
+- (void)addSubscriber:(id<UBApplicationStartupReasonReporterNotificationRelaySubscriber>)subscriber
+{
+    @synchronized(self.subscribersLockToken)
+    {
+        [self.subscribers addObject:subscriber];
+    }
+}
+
+- (void)removeSubscriber:(id<UBApplicationStartupReasonReporterNotificationRelaySubscriber>)subscriber
+{
+    @synchronized(self.subscribersLockToken)
+    {
+        [self.subscribers removeObject:subscriber];
+    }
+}
+
+- (void)updateApplicationStateNotification:(NSNotification *)notification
+{
+    @synchronized(self.subscribersLockToken)
+    {
+        for (id<UBApplicationStartupReasonReporterNotificationRelaySubscriber> subscriber in self.subscribers.allObjects) {
+            [subscriber processNotification:notification];
+        }
+    }
+}
+
+@end

--- a/StartupReasonReporter/StartupReasonReporter.h
+++ b/StartupReasonReporter/StartupReasonReporter.h
@@ -7,6 +7,7 @@
 
 #import "UBApplicationStartupReasonReporterPriorRunInfoProtocol.h"
 #import "UBApplicationStartupReasonReporter.h"
+#import "UBApplicationStartupReasonReporterNotificationRelay.h"
 #import "UBApplicationStartupReasonReporterPriorRunInfo.h"
 
 

--- a/StartupReasonReporter/StartupReasonReporter/UBApplicationStartupReasonReporter.h
+++ b/StartupReasonReporter/StartupReasonReporter/UBApplicationStartupReasonReporter.h
@@ -1,10 +1,11 @@
 //
-//  Copyright (c) 2016-2017 Uber Technologies, Inc. All rights reserved.
+//  Copyright (c) Uber Technologies, Inc. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+#import "UBApplicationStartupReasonReporterNotificationRelay.h"
 #import "UBApplicationStartupReasonReporterPriorRunInfoProtocol.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -60,17 +61,15 @@ NS_SWIFT_NAME(ApplicationStartupReasonReporter)
 /**
  Initializes a new UBApplicationStartupReasonReporter.
 
- @param notificationCenter The current NSNotificationCenter
  @param previousRunDidCrash Indicates whether the prior run was a crash
  @param previousRunInfo An implementation of UBApplicationStartupReasonReporterPriorRunInfoProtocol which contains information about the prior run and will store information about the current run.
+ @param notificationRelay the relay which emits application state update notifications.
  @param debugging True if this app run is for debugging, false otherwise.  This is useful if the app is being developed in the simulator, for instance.
- @param applicationState The current state of the application. This to tell if the app is being launched in the background.
  */
-- (instancetype)initWithNotificationCenter:(NSNotificationCenter *)notificationCenter
-                       previousRunDidCrash:(BOOL)previousRunDidCrash
-                           previousRunInfo:(id<UBApplicationStartupReasonReporterPriorRunInfoProtocol>)previousRunInfo
-                                 debugging:(BOOL)debugging
-                          applicationState:(UIApplicationState)applicationState;
+- (instancetype)initWithPreviousRunDidCrash:(BOOL)previousRunDidCrash
+                            previousRunInfo:(id<UBApplicationStartupReasonReporterPriorRunInfoProtocol>)previousRunInfo
+                          notificationRelay:(id<UBApplicationStartupReasonReporterNotificationRelayProtocol>)notificationRelay
+                                  debugging:(BOOL)debugging;
 
 @end
 

--- a/StartupReasonReporter/StartupReasonReporter/UBApplicationStartupReasonReporterPriorRunInfoProtocol.h
+++ b/StartupReasonReporter/StartupReasonReporter/UBApplicationStartupReasonReporterPriorRunInfoProtocol.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2017 Uber Technologies, Inc. All rights reserved.
+//  Copyright (c) Uber Technologies, Inc. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/StartupReasonReporter/StartupReasonReporterPriorRunInfo/UBApplicationStartupReasonReporterPriorRunInfo.h
+++ b/StartupReasonReporter/StartupReasonReporterPriorRunInfo/UBApplicationStartupReasonReporterPriorRunInfo.h
@@ -1,24 +1,23 @@
 //
-//  Copyright (c) 2017 Uber Technologies, Inc. All rights reserved.
+//  Copyright (c) Uber Technologies, Inc. All rights reserved.
 //
 
 #import "UBApplicationStartupReasonReporterPriorRunInfoProtocol.h"
 
 #import <Foundation/Foundation.h>
 
+
 /**
  An NSUserDefaults based implementation of UBApplicationStartupReasonReporterPriorRunInfoProtocol
  */
 NS_SWIFT_NAME(ApplicationStartupReasonReporterPriorRunInfo)
-
 @interface UBApplicationStartupReasonReporterPriorRunInfo : NSObject <UBApplicationStartupReasonReporterPriorRunInfoProtocol>
 
 /**
- Initializes a new UBApplicationStartupReasonReporterPriorRunInfo
-
- @param userDefaults The current user defaults
+ *  Returns the prior run information stored to disk at the given directory URL.
+ *  @param directoryURL The directory to use to to store the startup reason data.
+ *  @return the previous startup reason data if it was present on disk, or empty startup reason object.
  */
-- (nonnull instancetype)initWithUserDefaults:(nonnull NSUserDefaults *)userDefaults;
++ (nonnull instancetype)priorRunAtDirectoryURL:(nullable NSURL *)directoryURL;
 
 @end
-

--- a/StartupReasonReporter/StartupReasonReporterPriorRunInfo/UBApplicationStartupReasonReporterPriorRunInfo.m
+++ b/StartupReasonReporter/StartupReasonReporterPriorRunInfo/UBApplicationStartupReasonReporterPriorRunInfo.m
@@ -1,19 +1,21 @@
 //
-//  Copyright (c) 2017 Uber Technologies, Inc. All rights reserved.
+//  Copyright (c) Uber Technologies, Inc. All rights reserved.
 //
+
 #import "UBApplicationStartupReasonReporterPriorRunInfo.h"
 
-static NSString *const UBApplicationStartupResonReporterDataKey = @"appStartupReason";
-static NSString *const UBApplicationStartupResonReporterDataPreviousAppVersionKey = @"prevAppVersion";
-static NSString *const UBApplicationStartupResonReporterDataPreviousOSVersionKey = @"prevOSVersion";
-static NSString *const UBApplicationStartupResonReporterDataBackgroundedKey = @"backgrounded";
-static NSString *const UBApplicationStartupResonReporterDataDidTerminateKey = @"terminate";
-static NSString *const UBApplicationStartupResonReporterDataBootTimeKey = @"prevBootTime";
+static NSString *const UBApplicationStartupReasonReporterDataPreviousAppVersionKey = @"prevAppVersion";
+static NSString *const UBApplicationStartupReasonReporterDataPreviousOSVersionKey = @"prevOSVersion";
+static NSString *const UBApplicationStartupReasonReporterDataBackgroundedKey = @"backgrounded";
+static NSString *const UBApplicationStartupReasonReporterDataDidTerminateKey = @"terminate";
+static NSString *const UBApplicationStartupReasonReporterDataBootTimeKey = @"prevBootTime";
+
+static NSString *const UBApplicationStartupReasonReporterFilename = @"priorRunInfo.json";
 
 
 @interface UBApplicationStartupReasonReporterPriorRunInfo ()
 
-@property (nonatomic) NSUserDefaults *userDefaults;
+@property (nonatomic, nullable) NSURL *filepath;
 
 @end
 
@@ -27,49 +29,85 @@ static NSString *const UBApplicationStartupResonReporterDataBootTimeKey = @"prev
 @synthesize backgrounded = _backgrounded;
 @synthesize didTerminate = _didTerminate;
 
-- (instancetype)initWithUserDefaults:(NSUserDefaults *)userDefaults
++ (nonnull instancetype)priorRunAtDirectoryURL:(nullable NSURL *)directoryURL
 {
-    self = [super init];
-    if (self) {
-        NSDictionary *dict = [userDefaults dictionaryForKey:UBApplicationStartupResonReporterDataKey];
-        _userDefaults = userDefaults;
-
-        if (dict) {
-            _hasData = YES;
-
-            if (dict[UBApplicationStartupResonReporterDataPreviousAppVersionKey]) {
-                _previousAppVersion = dict[UBApplicationStartupResonReporterDataPreviousAppVersionKey];
-            }
-            if (dict[UBApplicationStartupResonReporterDataPreviousOSVersionKey]) {
-                _previousOSVersion = dict[UBApplicationStartupResonReporterDataPreviousOSVersionKey];
-            }
-            if ([dict[UBApplicationStartupResonReporterDataBackgroundedKey] isKindOfClass:[NSNumber class]]) {
-                _backgrounded = ((NSNumber *)dict[UBApplicationStartupResonReporterDataBackgroundedKey]).boolValue;
-            }
-            if ([dict[UBApplicationStartupResonReporterDataDidTerminateKey] isKindOfClass:[NSNumber class]]) {
-                _didTerminate = ((NSNumber *)dict[UBApplicationStartupResonReporterDataDidTerminateKey]).boolValue;
-            }
-            if ([dict[UBApplicationStartupResonReporterDataBootTimeKey] isKindOfClass:[NSNumber class]]) {
-                _previousBootTime = ((NSNumber *)dict[UBApplicationStartupResonReporterDataBootTimeKey]).longValue;
-            }
-        }
+    NSURL *filepath = [directoryURL URLByAppendingPathComponent:UBApplicationStartupReasonReporterFilename];
+    if (![[NSFileManager defaultManager] fileExistsAtPath:directoryURL.path isDirectory:nil]) {
+        [[NSFileManager defaultManager] createDirectoryAtPath:directoryURL.path withIntermediateDirectories:YES attributes:nil error:nil];
     }
-    return self;
+    UBApplicationStartupReasonReporterPriorRunInfo *priorRunInfo = [[UBApplicationStartupReasonReporterPriorRunInfo alloc] initWithFilepath:filepath];
+    if (priorRunInfo == nil) {
+        priorRunInfo = [[UBApplicationStartupReasonReporterPriorRunInfo alloc] init];
+    }
+    if (filepath != nil) {
+        priorRunInfo.filepath = filepath;
+    } else {
+        priorRunInfo.filepath = [[NSURL alloc] initWithString:NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES).firstObject];
+    }
+
+    return priorRunInfo;
 }
 
 - (void)persist
 {
-    NSDictionary *dict = @{
-        UBApplicationStartupResonReporterDataPreviousAppVersionKey : self.previousAppVersion ?: @"",
-        UBApplicationStartupResonReporterDataPreviousOSVersionKey : self.previousOSVersion ?: @"",
-        UBApplicationStartupResonReporterDataBackgroundedKey : @(self.backgrounded),
-        UBApplicationStartupResonReporterDataDidTerminateKey : @(self.didTerminate),
-        UBApplicationStartupResonReporterDataBootTimeKey : @(self.previousBootTime)
-    };
-    [self.userDefaults setObject:dict forKey:UBApplicationStartupResonReporterDataKey];
-    [self.userDefaults synchronize];
     self.hasData = YES;
+    [self writeToFilepath:self.filepath];
 }
 
+#pragma mark - Persistence Translation
+
+- (instancetype)initWithFilepath:(NSURL *)filepath
+{
+    NSData *data = [NSData dataWithContentsOfFile:filepath.path];
+    NSDictionary *dictionaryRepresentation = nil;
+    if (data != nil) {
+        NSError *error = nil;
+        dictionaryRepresentation = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&error];
+        NSAssert(error == nil, @"error found when deserializing startup reason data: %@", error.localizedDescription);
+    }
+    self = [super init];
+    if (self) {
+        if (dictionaryRepresentation != nil) {
+            _hasData = YES;
+            if ([dictionaryRepresentation[UBApplicationStartupReasonReporterDataPreviousAppVersionKey] isKindOfClass:[NSString class]]) {
+                _previousAppVersion = dictionaryRepresentation[UBApplicationStartupReasonReporterDataPreviousAppVersionKey];
+            }
+            if ([dictionaryRepresentation[UBApplicationStartupReasonReporterDataPreviousOSVersionKey] isKindOfClass:[NSString class]]) {
+                _previousOSVersion = dictionaryRepresentation[UBApplicationStartupReasonReporterDataPreviousOSVersionKey];
+            }
+            if ([dictionaryRepresentation[UBApplicationStartupReasonReporterDataBootTimeKey] isKindOfClass:[NSNumber class]]) {
+                _previousBootTime = [dictionaryRepresentation[UBApplicationStartupReasonReporterDataBootTimeKey] integerValue];
+            }
+            if ([dictionaryRepresentation[UBApplicationStartupReasonReporterDataBackgroundedKey] isKindOfClass:[NSNumber class]]) {
+                _backgrounded = [dictionaryRepresentation[UBApplicationStartupReasonReporterDataBackgroundedKey] boolValue];
+            }
+            if ([dictionaryRepresentation[UBApplicationStartupReasonReporterDataDidTerminateKey] isKindOfClass:[NSNumber class]]) {
+                _didTerminate = [dictionaryRepresentation[UBApplicationStartupReasonReporterDataDidTerminateKey] boolValue];
+            }
+        }
+    }
+
+    return self;
+}
+
+- (void)writeToFilepath:(NSURL *)filepath
+{
+    NSMutableDictionary *dictionaryRepresentation = [NSMutableDictionary dictionary];
+    if (self.previousAppVersion != nil) {
+        dictionaryRepresentation[UBApplicationStartupReasonReporterDataPreviousAppVersionKey] = self.previousAppVersion;
+    }
+    if (self.previousOSVersion) {
+        dictionaryRepresentation[UBApplicationStartupReasonReporterDataPreviousOSVersionKey] = self.previousOSVersion;
+    }
+    dictionaryRepresentation[UBApplicationStartupReasonReporterDataBootTimeKey] = [NSNumber numberWithInteger:self.previousBootTime];
+    dictionaryRepresentation[UBApplicationStartupReasonReporterDataBackgroundedKey] = [NSNumber numberWithBool:self.backgrounded];
+    dictionaryRepresentation[UBApplicationStartupReasonReporterDataDidTerminateKey] = [NSNumber numberWithBool:self.didTerminate];
+    NSError *error = nil;
+    NSData *data = [NSJSONSerialization dataWithJSONObject:dictionaryRepresentation options:kNilOptions error:&error];
+    NSAssert(error == nil, @"error found when serializing startup reason object: %@", error.localizedDescription);
+    error = nil;
+    [data writeToFile:filepath.path options:NSDataWritingAtomic error:&error];
+    NSAssert(error == nil, @"error found when writing startup reason object: %@", error.localizedDescription);
+}
 
 @end

--- a/StartupReasonReporterTests/UBApplicationStartupReasonReporterNotificationRelayTests.m
+++ b/StartupReasonReporterTests/UBApplicationStartupReasonReporterNotificationRelayTests.m
@@ -1,0 +1,68 @@
+//
+//  Copyright (c) Uber Technologies, Inc. All rights reserved.
+//
+
+#import "UBApplicationStartupReasonReporterNotificationRelay.h"
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+
+@interface UBApplicationStartupReasonReporterNotificationRelay ()
+
+@property (nonatomic, readonly) NSMutableSet<id<UBApplicationStartupReasonReporterNotificationRelaySubscriber>> *subscribers;
+
+@end
+
+
+@interface UBApplicationStartupReasonReporterNotificationRelayTests : XCTestCase
+
+@end
+
+
+@implementation UBApplicationStartupReasonReporterNotificationRelayTests
+
+- (void)test_addSubscriber
+{
+    id subscriber1 = OCMProtocolMock(@protocol(UBApplicationStartupReasonReporterNotificationRelaySubscriber));
+    id subscriber2 = OCMProtocolMock(@protocol(UBApplicationStartupReasonReporterNotificationRelaySubscriber));
+
+    UBApplicationStartupReasonReporterNotificationRelay *relay = [[UBApplicationStartupReasonReporterNotificationRelay alloc] init];
+    [relay addSubscriber:subscriber1];
+    [relay addSubscriber:subscriber2];
+
+    XCTAssert([relay.subscribers containsObject:subscriber1]);
+    XCTAssert([relay.subscribers containsObject:subscriber2]);
+}
+
+- (void)test_removeSubscriber
+{
+    id subscriber1 = OCMProtocolMock(@protocol(UBApplicationStartupReasonReporterNotificationRelaySubscriber));
+    id subscriber2 = OCMProtocolMock(@protocol(UBApplicationStartupReasonReporterNotificationRelaySubscriber));
+
+    UBApplicationStartupReasonReporterNotificationRelay *relay = [[UBApplicationStartupReasonReporterNotificationRelay alloc] init];
+    [relay addSubscriber:subscriber1];
+    [relay addSubscriber:subscriber2];
+    [relay removeSubscriber:subscriber1];
+    [relay removeSubscriber:subscriber2];
+
+    XCTAssertFalse([relay.subscribers containsObject:subscriber1]);
+    XCTAssertFalse([relay.subscribers containsObject:subscriber2]);
+}
+
+- (void)test_updateApplicationStateNotification
+{
+    id subscriber1 = OCMProtocolMock(@protocol(UBApplicationStartupReasonReporterNotificationRelaySubscriber));
+    id subscriber2 = OCMProtocolMock(@protocol(UBApplicationStartupReasonReporterNotificationRelaySubscriber));
+    NSNotification *notification = [[NSNotification alloc] initWithName:UIApplicationWillResignActiveNotification object:nil userInfo:nil];
+
+    UBApplicationStartupReasonReporterNotificationRelay *relay = [[UBApplicationStartupReasonReporterNotificationRelay alloc] init];
+    [relay addSubscriber:subscriber1];
+    [relay addSubscriber:subscriber2];
+    OCMExpect([subscriber1 processNotification:notification]);
+    OCMExpect([subscriber2 processNotification:notification]);
+    [relay updateApplicationStateNotification:notification];
+    OCMVerifyAll(subscriber1);
+    OCMVerifyAll(subscriber2);
+}
+
+@end

--- a/StartupReasonReporterTests/UBApplicationStartupReasonReporterPriorRunInfoTests.m
+++ b/StartupReasonReporterTests/UBApplicationStartupReasonReporterPriorRunInfoTests.m
@@ -1,0 +1,65 @@
+//
+//  Copyright (c) Uber Technologies, Inc. All rights reserved.
+//
+
+#import "UBApplicationStartupReasonReporterPriorRunInfo.h"
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+
+@interface UBApplicationStartupReasonReporterPriorRunInfoTests : XCTestCase
+
+@end
+
+
+@implementation UBApplicationStartupReasonReporterPriorRunInfoTests
+
+- (void)test_priorRunAtDirectoryURL
+{
+    NSMutableDictionary *dictionaryRepresentation = [NSMutableDictionary dictionary];
+    dictionaryRepresentation[@"prevAppVersion"] = @"test_version";
+    dictionaryRepresentation[@"prevOSVersion"] = @"test_os_version";
+    dictionaryRepresentation[@"prevBootTime"] = [NSNumber numberWithInteger:1];
+    dictionaryRepresentation[@"backgrounded"] = [NSNumber numberWithBool:YES];
+    dictionaryRepresentation[@"terminate"] = [NSNumber numberWithBool:YES];
+    NSData *data = [NSJSONSerialization dataWithJSONObject:dictionaryRepresentation options:kNilOptions error:nil];
+
+    NSURL *url = [NSURL URLWithString:@"test"];
+    id NSDataMock = OCMClassMock([NSData class]);
+    OCMStub([NSDataMock dataWithContentsOfFile:[url URLByAppendingPathComponent:@"priorRunInfo.json"].path]).andReturn(data);
+    UBApplicationStartupReasonReporterPriorRunInfo *info = [UBApplicationStartupReasonReporterPriorRunInfo priorRunAtDirectoryURL:url];
+
+    XCTAssertTrue([info.previousAppVersion isEqualToString:@"test_version"]);
+    XCTAssertTrue([info.previousOSVersion isEqualToString:@"test_os_version"]);
+    XCTAssertTrue(info.previousBootTime == 1);
+    XCTAssertTrue(info.backgrounded);
+    XCTAssertTrue(info.didTerminate);
+}
+
+- (void)test_persist
+{
+    __block UBApplicationStartupReasonReporterPriorRunInfo *info = [[UBApplicationStartupReasonReporterPriorRunInfo alloc] init];
+    info.previousAppVersion = @"test_version";
+    info.previousOSVersion = @"test_os_version";
+    info.previousBootTime = 1;
+    info.backgrounded = YES;
+    info.didTerminate = YES;
+
+    id NSJSONSerializationMock = OCMClassMock([NSJSONSerialization class]);
+    id dataMock = OCMPartialMock([NSData data]);
+    OCMStub([NSJSONSerializationMock dataWithJSONObject:OCMOCK_ANY options:kNilOptions error:[OCMArg anyObjectRef]]).andDo(^(NSInvocation *invocation) {
+                                                                                                                        __unsafe_unretained NSDictionary *dict = nil;
+                                                                                                                        [invocation getArgument:&dict atIndex:2];
+
+                                                                                                                        XCTAssertTrue([dict[@"prevAppVersion"] isEqualToString:info.previousAppVersion]);
+                                                                                                                        XCTAssertTrue([dict[@"prevOSVersion"] isEqualToString:info.previousOSVersion]);
+                                                                                                                        XCTAssertTrue([dict[@"backgrounded"] boolValue]);
+                                                                                                                        XCTAssertTrue([dict[@"terminate"] boolValue]);
+                                                                                                                        XCTAssertTrue([dict[@"prevBootTime"] integerValue] == 1);
+                                                                                                                    }).andReturn(dataMock);
+    OCMStub([dataMock writeToFile:OCMOCK_ANY options:NSDataWritingAtomic error:[OCMArg anyObjectRef]]).andReturn(YES);
+    [info persist];
+    OCMVerify([dataMock writeToFile:OCMOCK_ANY options:NSDataWritingAtomic error:[OCMArg anyObjectRef]]);
+}
+
+@end


### PR DESCRIPTION
Included in this PR:

- Updates to how startup reason is persisted to disk to ensure writes happen atomically.
- Use a notification relay for app state updates to improve accuracy by hooking into first notification update (in AppDelegate)
- Improve initial app state check to correctly record if the app is launched in the background or not.