### PR TITLE
Added missing includes to Podspec

### DIFF
--- a/StartupReasonReporter.podspec
+++ b/StartupReasonReporter.podspec
@@ -29,12 +29,15 @@ The Startup Reason Reporter provides developers the the reason that an iOS appli
   s.ios.deployment_target = '8.0'
 
   s.subspec 'Core' do |core|
-    core.source_files = 'StartupReasonReporter/StartupReasonReporter/*'
+    core.source_files = 'StartupReasonReporter/StartupReasonReporter/*', 'StartupReasonReporter/ApplicationStartupReasonReporterNotificationRelay/*'
   end
 
   s.subspec 'PriorRunInfo' do |pri|
     pri.source_files = 'StartupReasonReporter/StartupReasonReporterPriorRunInfo/*'
     pri.dependency 'StartupReasonReporter/Core'
   end
+
+
+
 
 end


### PR DESCRIPTION
Fixes issue #7

Class files related to `UBApplicationStartupReasonReporterNotificationRelay` appear to have accidentally been left out of the Podspec, causing the build to fail.

This PR adds ApplicationStartupReasonReporterNotificationRelay to Core. There is a chance that the intention is to create a subspec for these files, though. In that case, I leave it up to the team to decide on a way forward.
